### PR TITLE
Trust the system CA store in the OpenAI-compatible provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "url",
 ]
 
@@ -643,6 +644,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1587,7 +1598,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2175,7 +2186,7 @@ dependencies = [
  "reqwest 0.13.4",
  "ruma",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_html_form",
@@ -2581,6 +2592,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -3079,7 +3096,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3395,14 +3412,36 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3421,16 +3460,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3513,12 +3552,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4298,6 +4350,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ regex = "1.12.*"
 # HTTP client for the native `venice` provider. rustls only (no extra TLS stack), matching the
 # reqwest copy async-openai/matrix-sdk/mxlink already use.
 reqwest = { version = "0.13.*", default-features = false, features = ["json", "multipart", "rustls"] }
+# ureq copy etke_openai_api_rust uses. We enable `native-certs` so the OpenAI-compatible
+# provider trusts the system CA store (via rustls-native-certs, honouring SSL_CERT_FILE)
+# instead of only the bundled webpki-roots. Without this, endpoints behind a private/internal
+# CA fail with "invalid peer certificate: UnknownIssuer".
+ureq = { version = "2.*", default-features = false, features = ["tls", "gzip", "json", "native-certs"] }
 serde = { version = "1.0.*", features = ["derive"], default-features = false }
 serde_json = "1.0.*"
 serde_yaml_ng = "0.10.*"


### PR DESCRIPTION
### Problem

The OpenAI-compatible provider cannot connect to an endpoint whose TLS certificate is issued by a private/internal CA (an organization's own PKI, FreeIPA, etc.). The request fails during the TLS handshake with:

```
tls connection init failed: invalid peer certificate: UnknownIssuer
```

Meanwhile `curl` and the bot's own Matrix client reach the same host without any problem — they use the system trust store.

### Root cause

The OpenAI-compatible provider talks to the API through `etke_openai_api_rust`, which uses `ureq`. ureq's default `tls` feature builds the rustls root store **only from the bundled `webpki-roots`** (public Mozilla CAs) and does **not** consult the system trust store or `SSL_CERT_FILE`, so an internal CA is never trusted. (The `reqwest`/`async-openai` providers and the Matrix SDK are unaffected — they use the system roots.)

### Fix

Enable ureq's `native-certs` feature, so its roots come from `rustls-native-certs` (the system trust store, honoring `SSL_CERT_FILE`) instead of `webpki-roots`. baibot takes a direct dependency on `ureq` only to turn this feature on through Cargo feature unification — the same approach already used for the direct `reqwest` dependency.

The change is minimal: one dependency line in `Cargo.toml` (plus the updated `Cargo.lock`).

### How I tested

- Reproduced the failure: a request to an endpoint behind an internal CA with default ureq → `UnknownIssuer`.
- With `native-certs` enabled, the same request completes the TLS handshake (reaches the HTTP response).
- Running in production against an endpoint behind a FreeIPA CA on non-public DNS (internal network).

### Note for maintainers

The root cause really lives in `etke_openai_api_rust` (ureq with webpki-roots); enabling `native-certs` there would fix it for all consumers. The baibot-side fix is self-contained and needs no dependency release, though — your call.
